### PR TITLE
Prepare for better ext-network.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env*
 *.swp
+*.bak
+*.original
+custom.yml
 ext-network.yml

--- a/default.env
+++ b/default.env
@@ -67,6 +67,9 @@ WS_LB=opws-lb
 OPNODE_HOST=opnode
 OPNODE_LB=opnode-lb
 
+# External Docker network if using ext-network.yml
+DOCKER_EXT_NETWORK=traefik_default
+
 RPC_PORT=8545
 WS_PORT=8546
 OPGETH_P2P_PORT=30303
@@ -77,4 +80,4 @@ OPNODE_P2P_PORT=9222
 SCRIPT_TAG=
 
 # Used by optd update - please do not adjust
-ENV_VERSION=4
+ENV_VERSION=5

--- a/ethd
+++ b/ethd
@@ -58,7 +58,7 @@ __env_migrate() {
             L2GETH_DOCKER_TAG DOMAIN RPC_HOST RPC_LB OPNODE_HOST OPNODE_LB WS_HOST WS_LB RPC_PORT WS_PORT \
             OPGETH_P2P_PORT OPNODE_RPC_PORT OPNODE_P2P_PORT L2_CONNECTION_KIND OPNODE_SYNC_MODE GENESIS_URL ROLLUP_URL \
             OPGETH_P2P_BOOTNODES OPNODE_P2P_BOOTNODES OPNODE_P2P_STATIC_PEERS DISABLE_TXPOOL_GOSSIP SNAPSHOT_PART \
-            ROLLUP_HALT )
+            ROLLUP_HALT DOCKER_EXT_NETWORK )
   __old_vars=( )
   __new_vars=( )
 
@@ -664,6 +664,15 @@ update() {
       if [[ "${__branch}" =~ ^tag-* ]]; then
         git checkout main
       fi
+# Handle legacy ext-network. A future update after a hardfork will bring in the changed ext-network
+      DOCKER_EXT_NETWORK=$(${__as_owner} sed -n 's/^\s*name:\s*\(.*\)/\1/p' ext-network.yml)
+# I mean this literally
+# shellcheck disable=SC2016
+      if [ ! "${DOCKER_EXT_NETWORK:-"traefik_default"}" = '${DOCKER_EXT_NETWORK}' ]; then
+        __var=DOCKER_EXT_NETWORK
+        __update_value_in_env "${__var}" "${!__var}" "${__env_file}"
+      fi
+# End legacy handling
       ${__as_owner} git pull
     else
       export ETHDPINNED="${__value}"
@@ -733,6 +742,7 @@ find the original contents in ${__env_file}.bak."
 
 
 __prep_conffiles() {
+# Remove this after the next hardfork, when there's a new ext-network
 # Create ext-network.yml if it doesn't exist
   if [ ! -f "ext-network.yml" ]; then
     ${__as_owner} cp ext-network.yml.sample ext-network.yml

--- a/ethd
+++ b/ethd
@@ -558,7 +558,7 @@ __display_docker_volumes() {
     echo
   else
     echo "Here are the Docker volumes used by this copy of ${__project_name} and their space usage:"
-    __dodocker system df -v | grep -A 50 "VOLUME NAME" | grep "^$(basename "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
+    __dodocker system df -v | grep -A 500 "VOLUME NAME" | grep "^$(basename "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")"
     echo
   fi
   echo "If there is some mystery space being taken up, try \"sudo ncdu /\"."


### PR DESCRIPTION
This is part 1 of 2. Second part would come maybe a week after a hardfork

This prepares for ext-network.yml being tracked and having a variable

The second change would remove it from .gitignore, create it with that variable, remove sample, and remove the sample handling from ethd

This is tech debt that I introduced, and would like to see removed from Optimism Docker

I'll likely also remove it from Polygon Docker

Any other repos are up for discussion

New repos should be created without the sample to begin with, and with this new variable
