### PR TITLE
Add private config folder as a mount point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.original
 custom.yml
 ext-network.yml
+private-config/*
+!private-config/.hidden

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ The `./optd` script can be used as a quick-start:
 
 To update the software, run `./optd update` and then `./optd up`
 
+# For networks that use `genesis.json` and `rollup.json` files
+
+The repo supports both local and remote files for `genesis.json` and `rollup.json`. Using `https://` or `file://` it can detect to download the file or use a locally mounted file.
+
+To use a locally mounted file, add the files to `private-config` folder and then set the path as follows.
+
+```properties
+GENESIS_URL=file:///tmp/private-config/genesis-l2.json
+ROLLUP_URL=file:///tmp/private-config/rollup.json
+```
+
 # Other OP Stack chains
 
 Optimism Docker supports OP Stack chains that are not part of the Superchain Registry, or maybe are but still

--- a/optimism.yml
+++ b/optimism.yml
@@ -47,6 +47,7 @@ services:
       - opgeth-data:/var/lib/op-geth
       - jwtsecret:/var/lib/op-geth/ee-secret
       - /etc/localtime:/etc/localtime:ro
+      - ./private-config:/tmp/private-config:ro
     ports:
       - ${OPGETH_P2P_PORT:-30303}:${OPGETH_P2P_PORT:-30303}/tcp
       - ${OPGETH_P2P_PORT:-30303}:${OPGETH_P2P_PORT:-30303}/udp
@@ -141,6 +142,7 @@ services:
       - jwtsecret:/var/lib/op-node/ee-secret
       - opnode-data:/var/lib/op-node
       - /etc/localtime:/etc/localtime:ro
+      - ./private-config:/tmp/private-config:ro
     ports:
       - ${OPNODE_P2P_PORT:-9222}:${OPNODE_P2P_PORT:-9222}/tcp
       - ${OPNODE_P2P_PORT:-9222}:${OPNODE_P2P_PORT:-9222}/udp


### PR DESCRIPTION
For some chains, configs like `genesis.json` and `rollup.json` are not public or just want to use modified local files. In this case you want to mount them into the containers for op-geth and op-node.

This change creates a folder `private-config` which by default is empty except the placeholder empty file `.hidden`. One can add config files in that folder which is always mounted inside the container and then use `file://` syntax for URLs like below. By default curl and wget supports `file://` directive and will get the file locally without change in any other logic.

```properties
GENESIS_URL=file:///tmp/private-config/genesis-l2.json
ROLLUP_URL=file:///tmp/private-config/rollup.json
```