### PR TITLE
Allow opnode with non root user

### DIFF
--- a/default.env
+++ b/default.env
@@ -57,6 +57,7 @@ OPNODE_DOCKERFILE=Dockerfile.binary
 OPNODE_BIN_PATH=op-node
 OPNODE_DOCKER_TAG=latest
 OPNODE_DOCKER_REPO=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node
+OPNODE_ORIGINAL_USER=
 OPGETH_DOCKERFILE=Dockerfile.binary
 OPGETH_DOCKER_TAG=latest
 OPGETH_DOCKER_REPO=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth

--- a/default.env
+++ b/default.env
@@ -99,4 +99,4 @@ OPNODE_P2P_PORT=9222
 SCRIPT_TAG=
 
 # Used by optd update - please do not adjust
-ENV_VERSION=8
+ENV_VERSION=9

--- a/op-node/Dockerfile.binary
+++ b/op-node/Dockerfile.binary
@@ -1,7 +1,11 @@
 ARG DOCKER_TAG=latest
 ARG DOCKER_REPO=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node
+ARG ORIGINAL_USER=root
 
 FROM ${DOCKER_REPO}:${DOCKER_TAG}
+
+# Switch to root temporary
+USER root
 
 RUN apk update && apk add --no-cache ca-certificates tzdata bash curl su-exec
 
@@ -11,5 +15,8 @@ RUN mkdir -p /var/lib/op-node/ee-secret
 COPY ./docker-entrypoint.sh /usr/local/bin/
 # Belt and suspenders
 RUN chmod -R 755 /usr/local/bin/*
+
+# Restore the user
+USER ${ORIGINAL_USER}
 
 ENTRYPOINT ["op-node"]

--- a/optimism.yml
+++ b/optimism.yml
@@ -126,6 +126,7 @@ services:
       args:
         - DOCKER_TAG=${OPNODE_DOCKER_TAG}
         - DOCKER_REPO=${OPNODE_DOCKER_REPO}
+        - ORIGINAL_USER=${OPNODE_ORIGINAL_USER:-root}
     image: op-node:${NETWORK}
     pull_policy: never
     stop_grace_period: 1m


### PR DESCRIPTION
When op-node docker image uses non root user, then build stage fails with permission denied.

This allows it to proceed by following this steps
- Switches to root user when building
- Accepts ARG "ORIGINAL_USER" which by default is root, this will set the user for resulting build image to the original user if present