### PR TITLE
Add EigenDA v2 backend support for Celo Jovian hardfork

### DIFF
--- a/eigenda.yml
+++ b/eigenda.yml
@@ -16,6 +16,8 @@ services:
       - EIGENDA_LOCAL_DISPERSER_RPC=${EIGENDA_LOCAL_DISPERSER_RPC}
       - EIGENDA_LOCAL_SVC_MANAGER_ADDR=${EIGENDA_LOCAL_SVC_MANAGER_ADDR}
       - OP_NODE__RPC_ENDPOINT=${L1_RPC}
+      - EIGENDA_V2_LOCAL_NETWORK=${EIGENDA_V2_LOCAL_NETWORK}
+      - EIGENDA_V2_LOCAL_CERT_VERIFIER_ROUTER_ADDR=${EIGENDA_V2_LOCAL_CERT_VERIFIER_ROUTER_ADDR}
     volumes:
       - eigenda-data:/data
       - ./eigenda/docker-entrypoint.sh/:/scripts/start-eigenda-proxy.sh

--- a/eigenda/docker-entrypoint.sh
+++ b/eigenda/docker-entrypoint.sh
@@ -1,13 +1,36 @@
 #!/bin/sh
-set -eu
+set -e
+
+if [ -n "$EIGENDA_PROXY_ENDPOINT" ]; then
+  echo "Not starting local EigenDA proxy since proxy endpoint ($EIGENDA_PROXY_ENDPOINT) is defined"
+  exit
+fi
+
+if [ -n "$EIGENDA_LOCAL_ARCHIVE_BLOBS" ]; then
+  export EXTENDED_EIGENDA_PARAMETERS="${EXTENDED_EIGENDA_PARAMETERS:-} --s3.credential-type=$EIGENDA_LOCAL_S3_CREDENTIAL_TYPE \
+  --s3.access-key-id=$EIGENDA_LOCAL_S3_ACCESS_KEY_ID \
+  --s3.access-key-secret=$EIGENDA_LOCAL_S3_ACCESS_KEY_SECRET \
+  --s3.bucket=$EIGENDA_LOCAL_S3_BUCKET \
+  --s3.path=$EIGENDA_LOCAL_S3_PATH \
+  --s3.endpoint=$EIGENDA_LOCAL_S3_ENDPOINT \
+  --storage.fallback-targets=s3"
+fi
 
 exec ./eigenda-proxy --addr=0.0.0.0 \
   --port=4242 \
-  --eigenda.disperser-rpc="${EIGENDA_LOCAL_DISPERSER_RPC}" \
-  --eigenda.eth-rpc="${OP_NODE__RPC_ENDPOINT}" \
-  --eigenda.signer-private-key-hex="$(head -c 32 /dev/urandom | xxd -p -c 32)" \
-  --eigenda.svc-manager-addr="${EIGENDA_LOCAL_SVC_MANAGER_ADDR}" \
-  --eigenda.status-query-timeout="45m" \
+  --eigenda.disperser-rpc="$EIGENDA_LOCAL_DISPERSER_RPC" \
+  --eigenda.eth-rpc="$OP_NODE__RPC_ENDPOINT" \
+  --eigenda.svc-manager-addr="$EIGENDA_LOCAL_SVC_MANAGER_ADDR" \
   --eigenda.disable-tls=false \
-  --eigenda.confirmation-depth=1 \
-  --eigenda.max-blob-length="32MiB"
+  --eigenda.max-blob-length="16MiB" \
+  --storage.backends-to-enable="V1,V2" \
+  --eigenda.v2.eth-rpc="$OP_NODE__RPC_ENDPOINT" \
+  --eigenda.v2.disable-tls=false \
+  --eigenda.v2.blob-certified-timeout="2m" \
+  --eigenda.v2.contract-call-timeout="5s" \
+  --eigenda.v2.relay-timeout="5s" \
+  --eigenda.v2.max-blob-length="16MiB" \
+  --eigenda.v2.network="$EIGENDA_V2_LOCAL_NETWORK" \
+  --eigenda.v2.cert-verifier-router-or-immutable-verifier-addr="$EIGENDA_V2_LOCAL_CERT_VERIFIER_ROUTER_ADDR" \
+  --apis.enabled="op-generic,op-keccak,standard,metrics" \
+  $EXTENDED_EIGENDA_PARAMETERS

--- a/eigenda/docker-entrypoint.sh
+++ b/eigenda/docker-entrypoint.sh
@@ -16,6 +16,7 @@ if [ -n "$EIGENDA_LOCAL_ARCHIVE_BLOBS" ]; then
   --storage.fallback-targets=s3"
 fi
 
+# shellcheck disable=SC2086
 exec ./eigenda-proxy --addr=0.0.0.0 \
   --port=4242 \
   --eigenda.disperser-rpc="$EIGENDA_LOCAL_DISPERSER_RPC" \


### PR DESCRIPTION
## Summary
- Replace v1-only eigenda entrypoint with celo-org reference script supporting V1+V2 backends
- Add EigenDA v2 env vars (`EIGENDA_V2_LOCAL_NETWORK`, `EIGENDA_V2_LOCAL_CERT_VERIFIER_ROUTER_ADDR`) to eigenda.yml
- Required for Celo mainnet Jovian hardfork (March 31, 2026)